### PR TITLE
Adapt LDAP code for ldap3-0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ toml = "0.4.2"
 serde = "1.0.8"
 serde_derive = "1.0.8"
 libc = "0.2.24"
-# ldap3 = "0.4.4"
-ldap3 = { git = "https://github.com/inejge/ldap3.git", rev = "4b64268" }
+ldap3 = "0.5"
 rand = "0.3.15"
 
 [profile.release]


### PR DESCRIPTION
Version 0.5 of ldap3 has recently been published, with quite a few breaking changes, so I wanted to see how this crate, which is a reverse dependency, fared with the new version. I was delighted to see that it compiled flawlessly, but on inspection I saw that the code failed to account for the possibility of a non-zero result code from an LDAP Search. In ldap3-0.4 that would be a bit cumbersome to check, but it's much more straightforward in 0.5. That's one change, and the other is escaping the username when constructing the filter.